### PR TITLE
Chore: fix nginx 404 handling

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -10,6 +10,7 @@ server {
 
     location / {
         index  index.html;
+        try_files $uri /index.html =404;
     }
 
     location ~* ^.+\.(?:css|cur|js|jpe?g|gif|htc|ico|png|html|xml|otf|ttf|eot|woff|woff2|svg)$ {
@@ -17,6 +18,4 @@ server {
         add_header Cache-Control public;
         gzip_vary on;
     }
-
-    error_page  404  /index.html;
 }


### PR DESCRIPTION
Fixes the nginx 404 error handing by serving index.html if the path is not found.
The current config sends 404 and index.html. This is causing confusion for people looking at the web console.