### PR TITLE
fix: add loading status on critical path in issue

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -37,6 +37,8 @@ module.exports = {
     '@typescript-eslint/no-explicit-any': 0,
     '@typescript-eslint/no-var-requires': 0,
     '@typescript-eslint/no-use-before-define': 0,
+    // MEMO: inspired by https://github.com/typescript-eslint/typescript-eslint/issues/2621#issuecomment-701970389
+    'no-unused-vars': 'off',
     '@typescript-eslint/no-unused-vars': [
       2,
       {

--- a/src/common/components/charts/relay-blocks/relay-status-chart.tsx
+++ b/src/common/components/charts/relay-blocks/relay-status-chart.tsx
@@ -4,14 +4,10 @@ import usePolkabtcStats from '../../../hooks/use-polkabtc-stats';
 import { useSelector } from 'react-redux';
 import { StoreType } from '../../../types/util.types';
 
-// eslint-disable-next-line no-unused-vars
 enum Status {
-  // eslint-disable-next-line no-unused-vars
   Online,
-  // eslint-disable-next-line no-unused-vars
   Behind,
-  // eslint-disable-next-line no-unused-vars
-  NoData,
+  NoData
 }
 
 type RelayStatusChartProps = {

--- a/src/common/components/dashboard-table/dashboard-table.tsx
+++ b/src/common/components/dashboard-table/dashboard-table.tsx
@@ -43,17 +43,13 @@ function StyledLinkData(props: StyledLinkDataProps): ReactElement {
 /**
  * Helper component to display status text, with appropriate colour and status icon
  **/
-// eslint-disable-next-line no-unused-vars
 enum StatusCategories {
-  // eslint-disable-next-line no-unused-vars
   Bad,
-  // eslint-disable-next-line no-unused-vars
   Warning,
-  // eslint-disable-next-line no-unused-vars
   Ok,
-  // eslint-disable-next-line no-unused-vars
-  Neutral,
+  Neutral
 }
+
 type StatusComponentProps = {
     text: string;
     category: StatusCategories;

--- a/src/common/types/issue.types.ts
+++ b/src/common/types/issue.types.ts
@@ -22,22 +22,14 @@ export interface IssueRequest {
 }
 
 export enum IssueRequestStatus {
-  // eslint-disable-next-line no-unused-vars
   Completed,
-  // eslint-disable-next-line no-unused-vars
   Cancelled,
-  // eslint-disable-next-line no-unused-vars
   RequestedRefund,
-  // eslint-disable-next-line no-unused-vars
   Expired,
-  // eslint-disable-next-line no-unused-vars
   PendingWithBtcTxNotFound,
-  // eslint-disable-next-line no-unused-vars
   PendingWithBtcTxNotIncluded,
-  // eslint-disable-next-line no-unused-vars
   PendingWithTooFewConfirmations,
-  // eslint-disable-next-line no-unused-vars
-  PendingWithEnoughConfirmations,
+  PendingWithEnoughConfirmations
 }
 
 export type DashboardIssueInfo = {

--- a/src/common/types/redeem.types.ts
+++ b/src/common/types/redeem.types.ts
@@ -14,22 +14,14 @@ export interface RedeemRequest {
 }
 
 export enum RedeemRequestStatus {
-  // eslint-disable-next-line no-unused-vars
   Completed,
-  // eslint-disable-next-line no-unused-vars
   Expired,
-  // eslint-disable-next-line no-unused-vars
   Reimbursed,
-  // eslint-disable-next-line no-unused-vars
   Retried,
-  // eslint-disable-next-line no-unused-vars
   PendingWithBtcTxNotFound,
-  // eslint-disable-next-line no-unused-vars
   PendingWithBtcTxNotIncluded,
-  // eslint-disable-next-line no-unused-vars
   PendingWithTooFewConfirmations,
-  // eslint-disable-next-line no-unused-vars
-  PendingWithEnoughConfirmations,
+  PendingWithEnoughConfirmations
 }
 
 export type DashboardRequestInfo = {

--- a/src/common/types/util.types.ts
+++ b/src/common/types/util.types.ts
@@ -38,14 +38,10 @@ export interface DashboardStatusUpdateInfo {
 }
 
 export enum ParachainStatus {
-  // eslint-disable-next-line no-unused-vars
   Loading,
-  // eslint-disable-next-line no-unused-vars
   Error,
-  // eslint-disable-next-line no-unused-vars
   Running,
-  // eslint-disable-next-line no-unused-vars
-  Shutdown,
+  Shutdown
 }
 
 export type Prices = {

--- a/src/pages/app/issue/btc-payment.tsx
+++ b/src/pages/app/issue/btc-payment.tsx
@@ -23,7 +23,7 @@ export default function BTCPayment(): ReactElement {
     <React.Fragment>
       <FormGroup>{request && <PaymentView request={request}></PaymentView>}</FormGroup>
       <button
-        className='btn green-button app-btn '
+        className='btn green-button app-btn'
         onClick={submit}>
         {t('issue_page.made_payment')}
       </button>

--- a/src/pages/app/issue/enter-btc-amount.tsx
+++ b/src/pages/app/issue/enter-btc-amount.tsx
@@ -43,6 +43,16 @@ import { ReactComponent as PolkadotLogoIcon } from 'assets/img/polkadot-logo.svg
 import { ACCOUNT_ID_TYPE_NAME } from '../../../constants';
 import ParachainStatusInfo from 'components/ParachainStatusInfo';
 
+// eslint-disable-next-line no-unused-vars
+enum IssueState {
+  // eslint-disable-next-line no-unused-vars
+  LOADING,
+  // eslint-disable-next-line no-unused-vars
+  SUCCESS,
+  // eslint-disable-next-line no-unused-vars
+  ERROR,
+}
+
 type EnterBTCForm = {
   amountPolkaBTC: string;
 }
@@ -50,6 +60,9 @@ type EnterBTCForm = {
 function EnterBTCAmount(): JSX.Element {
   const dispatch = useDispatch();
   const { t } = useTranslation();
+
+  // status
+  const [issueState, setIssueState] = useState(IssueState.LOADING);
 
   const {
     polkaBtcLoaded,
@@ -71,9 +84,10 @@ function EnterBTCAmount(): JSX.Element {
   } = useForm<EnterBTCForm>(defaultValues);
 
   // Additional info: bridge fee, security deposit, amount BTC
-  const [feeRate, setFeeRate] = useState(new Big(0));
+  // Current fee model specification taken from: https://interlay.gitlab.io/polkabtc-spec/spec/fee.html
+  const [feeRate, setFeeRate] = useState(new Big(0.005)); // set default to 0.5%
   const [fee, setFee] = useState('0');
-  const [depositRate, setDepositRate] = useState(new Big(0));
+  const [depositRate, setDepositRate] = useState(new Big(0.00005)); // set default to 0.005%
   const [deposit, setDeposit] = useState('0');
   const [amountBTC, setAmountBTC] = useState('0');
   const [btcToDotRate, setBtcToDotRate] = useState(new Big(0));
@@ -91,7 +105,10 @@ function EnterBTCAmount(): JSX.Element {
 
   // Load issue related data
   useEffect(() => {
-    const fetchData = async () => {
+    // Loading this data is not strictly required as long as the constantly set values did
+    // not change. However, you will not see the correct value for the security deposit.
+    // But not having this data will NOT block the requestIssue
+    const fetchFeeData = async () => {
       if (!polkaBtcLoaded) return;
 
       try {
@@ -100,14 +117,12 @@ function EnterBTCAmount(): JSX.Element {
           depositRate,
           issuePeriodInBlocks,
           dustValueAsSatoshi,
-          vaultsMap,
           btcToDot
         ] = await Promise.all([
           window.polkaBTC.issue.getFeeRate(),
           window.polkaBTC.fee.getIssueGriefingCollateralRate(),
           window.polkaBTC.issue.getIssuePeriod(),
           window.polkaBTC.redeem.getDustValue(),
-          window.polkaBTC.vaults.getVaultsWithIssuableTokens(),
           window.polkaBTC.oracle.getExchangeRate()
         ]);
         // Set bridge fee rate
@@ -120,21 +135,35 @@ function EnterBTCAmount(): JSX.Element {
         // Set dust value (minimum amount)
         const dustValueBtc = satToBTC(dustValueAsSatoshi.toString());
         setDustValue(dustValueBtc);
-        // Set the vault maximum
-        let maxVaultAmount = new BN(0);
-        for (const issuableTokens of vaultsMap.values()) {
-          maxVaultAmount = issuableTokens.toBn();
-          break;
-        }
-        setVaultMaxAmount(satToBTC(maxVaultAmount.toString()));
-        setVaults(vaultsMap);
         // Set exchange rate
         setBtcToDotRate(btcToDot);
       } catch (error) {
         console.log('[EnterBtcAmount useEffect] error.message => ', error.message);
       }
     };
-    fetchData();
+    // This data (the vaults) is strictly required to request issue
+    const fetchVaultData = async () => {
+      if (!polkaBtcLoaded) return;
+
+      try {
+        const vaultsMap = await window.polkaBTC.vaults.getVaultsWithIssuableTokens();
+        // Set the vault maximum
+        let maxVaultAmount = new BN(0);
+        // first item in the ma is the vault with the largest capacity
+        for (const issuableTokens of vaultsMap.values()) {
+          maxVaultAmount = issuableTokens.toBn();
+          break;
+        }
+        setVaultMaxAmount(satToBTC(maxVaultAmount.toString()));
+        setVaults(vaultsMap);
+        setIssueState(IssueState.SUCCESS);
+      } catch (error) {
+        console.log('[EnterBtcAmount useEffect] error.message => ', error.message);
+        setIssueState(IssueState.ERROR);
+      }
+    };
+    fetchFeeData();
+    fetchVaultData();
   }, [
     polkaBtcLoaded,
     dispatch
@@ -153,7 +182,7 @@ function EnterBTCAmount(): JSX.Element {
       setFee(fee.toString());
       // Update security deposit
       const deposit = amountPolkaBTC.mul(btcToDotRate).mul(depositRate);
-      setDeposit(deposit.toString());
+      setDeposit(deposit.round(8).toString());
       // Update total BTC
       const amountBTC = amountPolkaBTC.add(fee);
       setAmountBTC(amountBTC.toString());
@@ -346,7 +375,11 @@ function EnterBTCAmount(): JSX.Element {
       </div>
       <ButtonMaybePending
         className='btn green-button app-btn'
-        disabled={parachainStatus !== ParachainStatus.Running || !address}
+        disabled={
+          parachainStatus !== ParachainStatus.Running ||
+          !address ||
+          issueState !== IssueState.SUCCESS
+        }
         isPending={isRequestPending}
         onClick={onSubmit}>
         {t('confirm')}

--- a/src/pages/app/issue/enter-btc-amount.tsx
+++ b/src/pages/app/issue/enter-btc-amount.tsx
@@ -44,9 +44,9 @@ import { ACCOUNT_ID_TYPE_NAME } from '../../../constants';
 import ParachainStatusInfo from 'components/ParachainStatusInfo';
 
 enum IssueState {
-  LOADING,
-  SUCCESS,
-  ERROR
+  Loading,
+  Resolved,
+  Rejected
 }
 
 type EnterBTCForm = {
@@ -57,8 +57,7 @@ function EnterBTCAmount(): JSX.Element {
   const dispatch = useDispatch();
   const { t } = useTranslation();
 
-  // status
-  const [issueState, setIssueState] = useState(IssueState.LOADING);
+  const [issueState, setIssueState] = useState(IssueState.Loading);
 
   const {
     polkaBtcLoaded,
@@ -137,6 +136,7 @@ function EnterBTCAmount(): JSX.Element {
         console.log('[EnterBtcAmount useEffect] error.message => ', error.message);
       }
     };
+
     // This data (the vaults) is strictly required to request issue
     const fetchVaultData = async () => {
       if (!polkaBtcLoaded) return;
@@ -152,10 +152,10 @@ function EnterBTCAmount(): JSX.Element {
         }
         setVaultMaxAmount(satToBTC(maxVaultAmount.toString()));
         setVaults(vaultsMap);
-        setIssueState(IssueState.SUCCESS);
+        setIssueState(IssueState.Resolved);
       } catch (error) {
         console.log('[EnterBtcAmount useEffect] error.message => ', error.message);
-        setIssueState(IssueState.ERROR);
+        setIssueState(IssueState.Rejected);
       }
     };
     fetchFeeData();
@@ -374,7 +374,7 @@ function EnterBTCAmount(): JSX.Element {
         disabled={
           parachainStatus !== ParachainStatus.Running ||
           !address ||
-          issueState !== IssueState.SUCCESS
+          issueState !== IssueState.Resolved
         }
         isPending={isRequestPending}
         onClick={onSubmit}>

--- a/src/pages/app/issue/enter-btc-amount.tsx
+++ b/src/pages/app/issue/enter-btc-amount.tsx
@@ -43,14 +43,10 @@ import { ReactComponent as PolkadotLogoIcon } from 'assets/img/polkadot-logo.svg
 import { ACCOUNT_ID_TYPE_NAME } from '../../../constants';
 import ParachainStatusInfo from 'components/ParachainStatusInfo';
 
-// eslint-disable-next-line no-unused-vars
 enum IssueState {
-  // eslint-disable-next-line no-unused-vars
   LOADING,
-  // eslint-disable-next-line no-unused-vars
   SUCCESS,
-  // eslint-disable-next-line no-unused-vars
-  ERROR,
+  ERROR
 }
 
 type EnterBTCForm = {

--- a/src/pages/dashboard/components/btc-relay.tsx
+++ b/src/pages/dashboard/components/btc-relay.tsx
@@ -10,14 +10,10 @@ import { PAGES } from 'utils/constants/links';
 import DashboardCard from 'pages/dashboard/DashboardCard';
 import clsx from 'clsx';
 
-// eslint-disable-next-line no-unused-vars
 enum Status {
-  // eslint-disable-next-line no-unused-vars
   Loading,
-  // eslint-disable-next-line no-unused-vars
   Ok,
-  // eslint-disable-next-line no-unused-vars
-  Failure,
+  Failure
 }
 
 type BtcRelayProps = {

--- a/src/pages/dashboard/components/oracle-status.tsx
+++ b/src/pages/dashboard/components/oracle-status.tsx
@@ -9,16 +9,11 @@ import usePolkabtcStats from 'common/hooks/use-polkabtc-stats';
 import ButtonComponent from './button-component';
 import { getAccents } from '../dashboardcolors';
 
-// eslint-disable-next-line no-unused-vars
 enum Status {
-  // eslint-disable-next-line no-unused-vars
   Loading,
-  // eslint-disable-next-line no-unused-vars
   Online,
-  // eslint-disable-next-line no-unused-vars
   Offline,
-  // eslint-disable-next-line no-unused-vars
-  NoData,
+  NoData
 }
 
 type OracleStatusProps = {

--- a/src/pages/vault-dashboard/update-collateral/update-collateral.tsx
+++ b/src/pages/vault-dashboard/update-collateral/update-collateral.tsx
@@ -12,14 +12,11 @@ import { useTranslation } from 'react-i18next';
 import { DOT } from '@interlay/polkabtc/build/interfaces';
 import { ACCOUNT_ID_TYPE_NAME } from '../../../constants';
 
-// Commenting because moving this to last line casues 3 "used before it was defined" warnings
+// Commenting because moving this to last line causes 3 "used before it was defined" warnings
 // eslint-disable-next-line import/exports-last
 export enum CollateralUpdateStatus {
-  // eslint-disable-next-line no-unused-vars
   Hidden,
-  // eslint-disable-next-line no-unused-vars
   Increase,
-  // eslint-disable-next-line no-unused-vars
   Decrease
 }
 

--- a/src/utils/enums/tab-types.ts
+++ b/src/utils/enums/tab-types.ts
@@ -1,9 +1,6 @@
 
 export enum TabTypes {
-  // eslint-disable-next-line no-unused-vars
   Issue,
-  // eslint-disable-next-line no-unused-vars
   Redeem,
-  // eslint-disable-next-line no-unused-vars
   Transfer
 }


### PR DESCRIPTION
This is a start to have dedicated state on the issue app and prevent request to issue PolkaBTC if not all data is loaded.

Should prevent:
- [x] Requesting to issue when not all the vaults are loaded
- [x] Separate the non-critical data from the critical data to load and thereby not block the request if the non-critical data is not yet loaded

Open points:
- [ ] We should cache the exchange rate since this is used across many pages and components
- [ ] We should cache the issue fee rate, and deposit fee rate because they rarely change (maybe every couple of months or so)
- [ ] The "CONFIRM" button should show "LOADING" while the issue page is still loading.