### PR TITLE
Chore: merged gitlab-ci.yml

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,4 +1,4 @@
-image: node:16-buster
+image: node:15-buster
 
 stages:
   - test


### PR DESCRIPTION
Use nodejs v15 instead of v16 due to lack of support for node-sass.