### PR TITLE
fixed broken date display on several pages

### DIFF
--- a/src/pages/Application/issue/IssueRequests.tsx
+++ b/src/pages/Application/issue/IssueRequests.tsx
@@ -103,7 +103,7 @@ function IssueRequests(): JSX.Element {
                     className='table-row-opens-modal'>
                     <td>
                       {request.timestamp ?
-                        formatDateTimePrecise(new Date(request.timestamp)) :
+                        formatDateTimePrecise(new Date(Number(request.timestamp))) :
                         t('pending')}
                     </td>
                     <td>

--- a/src/pages/Application/issue/modal/PaymentView.tsx
+++ b/src/pages/Application/issue/modal/PaymentView.tsx
@@ -32,7 +32,7 @@ const PaymentView = ({
   React.useEffect(() => {
     if (!request.timestamp) return;
 
-    const requestTimestamp = Math.floor(new Date(request.timestamp).getTime() / 1000);
+    const requestTimestamp = Math.floor(new Date(Number(request.timestamp)).getTime() / 1000);
     const theInitialLeftSeconds = requestTimestamp + issuePeriod - Math.floor(Date.now() / 1000);
     setInitialLeftSeconds(theInitialLeftSeconds);
   }, [

--- a/src/pages/Application/redeem/RedeemRequests.tsx
+++ b/src/pages/Application/redeem/RedeemRequests.tsx
@@ -86,7 +86,7 @@ export default function RedeemRequests(): ReactElement {
                       className='table-row-opens-modal'>
                       <td>
                         {request.timestamp ?
-                          formatDateTimePrecise(new Date(request.timestamp)) :
+                          formatDateTimePrecise(new Date(Number(request.timestamp))) :
                           t('pending')}
                       </td>
                       <td>{request.amountPolkaBTC} BTC</td>

--- a/src/pages/dashboard/parachain/parachain.dashboard.page.tsx
+++ b/src/pages/dashboard/parachain/parachain.dashboard.page.tsx
@@ -78,7 +78,7 @@ export default function ParachainDashboard(): ReactElement {
   const tableStatusUpdateRow = useMemo(
     () => (updt: DashboardStatusUpdateInfo): ReactElement[] => [
       <p key={1}>{updt.id}</p>,
-      <p key={2}>{formatDateTimePrecise(new Date(updt.timestamp))}</p>,
+      <p key={2}>{formatDateTimePrecise(new Date(Number(updt.timestamp)))}</p>,
       <p key={3}>
         {updt.addError ?
           [t('dashboard.parachain.add_error', { error: updt.addError }), updt.removeError ? <br /> : ''] :


### PR DESCRIPTION
This fixes "invalid date" or "NaN" date display on a few pages.

This is a quickfix, with the unification of request types the timestamp should be passed properly as a number, but currently it's a string and would require a stats update to change back + changing type structs in the UI + some other places already assume it's a string.